### PR TITLE
Fix double XOR'ing Sav3 item count when writing

### DIFF
--- a/source/sav/Sav3.cpp
+++ b/source/sav/Sav3.cpp
@@ -652,10 +652,7 @@ const std::set<int>& Sav3::availableBalls(void) const
 
 void Sav3::item(const Item& item, Pouch pouch, u16 slot)
 {
-    Item3 inject = (Item3)item;
-    if (pouch != Pouch::PCItem)
-        inject.count(inject.count() ^ (u16)securityKey());
-    auto write = inject.bytes();
+    auto write = item.bytes();
     switch (pouch)
     {
         case NormalItem:


### PR DESCRIPTION
When I changed it to undo the XOR for getting bytes of an Item3 (0dd53933901200c9c457ea2db100ba97ad37c96f) I forgot to remove the XOR to the bytes in Sav3::item()'s write function

---

This is tested working with RS, E, and FRLG in pkmn-chest.