### PR TITLE
Fix setting ability on single ability Pokemon (PK3)

### DIFF
--- a/source/pkx/PK3.cpp
+++ b/source/pkx/PK3.cpp
@@ -836,13 +836,13 @@ Ability PK3::ability() const
 }
 void PK3::ability(Ability v)
 {
-    if (v == abilities(1))
-    {
-        abilityBit(true);
-    }
-    else if (v == abilities(0))
+    if (v == abilities(0))
     {
         abilityBit(false);
+    }
+    else if (v == abilities(1))
+    {
+        abilityBit(true);
     }
 }
 void PK3::setAbility(u8 num)


### PR DESCRIPTION
This changes PK3 to assign ability 0 before ability 1 if their both the same since in game single ability Pokemon have their ability and none instead of their ability twice so by defaulting to 1 it'd be no ability in game since personal says they have the same ability twice.