### PR TITLE
Update the PKSM_MAX_SPECIES to Calyrex.

### DIFF
--- a/include/pkx/PKX.hpp
+++ b/include/pkx/PKX.hpp
@@ -90,7 +90,7 @@ namespace pksm
         u8* data;
 
     public:
-        static constexpr Species PKSM_MAX_SPECIES = Species::Zarude;
+        static constexpr Species PKSM_MAX_SPECIES = Species::Calyrex;
 
         [[nodiscard]] static std::unique_ptr<PKX> getPKM(
             Generation gen, u8* data, bool party = false, bool directAccess = false);


### PR DESCRIPTION
This was still set on Zarude. This is checked in the PKSM function `pkx_is_valid()`

https://github.com/FlagBrew/PKSM/blob/1c6200819cf44ae822c2e350a45d913609fd1c7a/3ds/source/picoc/pksm_api.cpp#L1193