### PR TITLE
Fix resetting nature in PK3 -> PK4, breaking gender, alt form, nature, shininess in PK4 -> PK3

### DIFF
--- a/include/pkx/PKX.hpp
+++ b/include/pkx/PKX.hpp
@@ -168,8 +168,8 @@ namespace pksm
         void fixMoves(void);
 
         [[nodiscard]] static u32 getRandomPID(Species species, Gender gender,
-            GameVersion originGame, Nature nature, u8 form, u8 abilityNum, u32 oldPid,
-            Generation gen);
+            GameVersion originGame, Nature nature, u8 form, u8 abilityNum, bool shiny, u16 tsv,
+            u32 oldPid, Generation gen);
         [[nodiscard]] static Gender genderFromRatio(u32 pid, u8 gt);
 
         // BLOCK A

--- a/source/pkx/PB7.cpp
+++ b/source/pkx/PB7.cpp
@@ -401,22 +401,8 @@ namespace pksm
     bool PB7::shiny(void) const { return TSV() == PSV(); }
     void PB7::shiny(bool v)
     {
-        if (v)
-        {
-            while (!shiny())
-            {
-                PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            }
-        }
-        else
-        {
-            while (shiny())
-            {
-                PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            }
-        }
+        PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
+            abilityNumber(), v, TSV(), PID(), generation()));
     }
 
     u16 PB7::formSpecies(void) const

--- a/source/pkx/PK3.cpp
+++ b/source/pkx/PK3.cpp
@@ -695,8 +695,8 @@ namespace pksm
     Nature PK3::nature() const { return Nature{u8(PID() % 25)}; }
     void PK3::nature(Nature v)
     {
-        PID(PKX::getRandomPID(species(), gender(), version(), v, alternativeForm(),
-            abilityBit() ? 2 : 1, PID(), Generation::THREE));
+        PID(PKX::getRandomPID(species(), gender(), version(), v, alternativeForm(), abilityNumber(),
+            shiny(), TSV(), PID(), Generation::THREE));
     }
 
     Gender PK3::gender() const
@@ -715,8 +715,8 @@ namespace pksm
     }
     void PK3::gender(Gender v)
     {
-        PID(PKX::getRandomPID(species(), v, version(), nature(), alternativeForm(),
-            abilityBit() ? 2 : 1, PID(), Generation::THREE));
+        PID(PKX::getRandomPID(species(), v, version(), nature(), alternativeForm(), abilityNumber(),
+            shiny(), TSV(), PID(), Generation::THREE));
     }
 
     u16 PK3::alternativeForm() const
@@ -731,8 +731,8 @@ namespace pksm
     {
         if (species() == Species::Unown)
         {
-            PID(PKX::getRandomPID(species(), gender(), version(), nature(), v, abilityBit() ? 2 : 1,
-                PID(), Generation::THREE));
+            PID(PKX::getRandomPID(species(), gender(), version(), nature(), v, abilityNumber(),
+                shiny(), TSV(), PID(), Generation::THREE));
         }
     }
 
@@ -790,22 +790,8 @@ namespace pksm
     bool PK3::shiny(void) const { return TSV() == PSV(); }
     void PK3::shiny(bool v)
     {
-        if (v)
-        {
-            while (!shiny())
-            {
-                PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            }
-        }
-        else
-        {
-            while (shiny())
-            {
-                PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            }
-        }
+        PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
+            abilityNumber(), v, TSV(), PID(), generation()));
     }
 
     u16 PK3::formSpecies() const { return u16(species()); }

--- a/source/pkx/PK3.cpp
+++ b/source/pkx/PK3.cpp
@@ -478,6 +478,7 @@ namespace pksm
         pk4->experience(egg() ? expTable(5, expType()) : experience());
         pk4->gender(gender());
         pk4->alternativeForm(alternativeForm());
+        pk4->nature(nature());
         pk4->egg(false);
         pk4->otFriendship(70);
         pk4->markValue(markValue());

--- a/source/pkx/PK4.cpp
+++ b/source/pkx/PK4.cpp
@@ -274,22 +274,8 @@ namespace pksm
     u8 PK4::abilityNumber(void) const { return 1 << (PID() & 1); }
     void PK4::abilityNumber(u8 v)
     {
-        if (shiny())
-        {
-            do
-            {
-                PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
-                    v, PID(), generation()));
-            } while (!shiny());
-        }
-        else
-        {
-            do
-            {
-                PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
-                    v, PID(), generation()));
-            } while (shiny());
-        }
+        PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(), v,
+            shiny(), TSV(), PID(), generation()));
     }
 
     u32 PK4::PID(void) const { return LittleEndian::convertTo<u32>(data); }
@@ -417,22 +403,8 @@ namespace pksm
     void PK4::gender(Gender g)
     {
         data[0x40] = (data[0x40] & ~0x06) | (u8(g) << 1);
-        if (shiny())
-        {
-            do
-            {
-                PID(PKX::getRandomPID(species(), g, version(), nature(), alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            } while (!shiny());
-        }
-        else
-        {
-            do
-            {
-                PID(PKX::getRandomPID(species(), g, version(), nature(), alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            } while (shiny());
-        }
+        PID(PKX::getRandomPID(species(), g, version(), nature(), alternativeForm(), abilityNumber(),
+            shiny(), TSV(), PID(), generation()));
     }
 
     u16 PK4::alternativeForm(void) const { return data[0x40] >> 3; }
@@ -441,22 +413,8 @@ namespace pksm
     Nature PK4::nature(void) const { return Nature{u8(PID() % 25)}; }
     void PK4::nature(Nature v)
     {
-        if (shiny())
-        {
-            do
-            {
-                PID(PKX::getRandomPID(species(), gender(), version(), v, alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            } while (!shiny());
-        }
-        else
-        {
-            do
-            {
-                PID(PKX::getRandomPID(species(), gender(), version(), v, alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            } while (shiny());
-        }
+        PID(PKX::getRandomPID(species(), gender(), version(), v, alternativeForm(), abilityNumber(),
+            shiny(), TSV(), PID(), generation()));
     }
 
     u8 PK4::shinyLeaf(void) const { return data[0x41]; }
@@ -677,22 +635,8 @@ namespace pksm
     bool PK4::shiny(void) const { return TSV() == PSV(); }
     void PK4::shiny(bool v)
     {
-        if (v)
-        {
-            while (!shiny())
-            {
-                PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            }
-        }
-        else
-        {
-            while (shiny())
-            {
-                PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            }
-        }
+        PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
+            abilityNumber(), v, TSV(), PID(), generation()));
     }
 
     u16 PK4::formSpecies(void) const
@@ -812,9 +756,9 @@ namespace pksm
     {
         auto pk3 = PKX::getPKM<Generation::THREE>(nullptr);
 
-        // This sets gender, nature, and alternative form as well
+        // This sets gender, nature, alternative form, and shininess as well
         pk3->PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
-            abilityNumber(), PID(), Generation::THREE));
+            abilityNumber(), shiny(), TSV(), PID(), Generation::THREE));
 
         pk3->species(species());
         pk3->TID(TID());

--- a/source/pkx/PK4.cpp
+++ b/source/pkx/PK4.cpp
@@ -819,6 +819,7 @@ namespace pksm
         pk3->experience(egg() ? expTable(5, expType()) : experience());
         pk3->gender(gender());
         pk3->alternativeForm(alternativeForm());
+        pk3->nature(nature());
         pk3->egg(false);
         pk3->otFriendship(70);
         pk3->markValue(markValue());

--- a/source/pkx/PK4.cpp
+++ b/source/pkx/PK4.cpp
@@ -812,14 +812,14 @@ namespace pksm
     {
         auto pk3 = PKX::getPKM<Generation::THREE>(nullptr);
 
-        pk3->PID(PID());
+        // This sets gender, nature, and alternative form as well
+        pk3->PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
+            abilityNumber(), PID(), Generation::THREE));
+
         pk3->species(species());
         pk3->TID(TID());
         pk3->SID(SID());
         pk3->experience(egg() ? expTable(5, expType()) : experience());
-        pk3->gender(gender());
-        pk3->alternativeForm(alternativeForm());
-        pk3->nature(nature());
         pk3->egg(false);
         pk3->otFriendship(70);
         pk3->markValue(markValue());

--- a/source/pkx/PK5.cpp
+++ b/source/pkx/PK5.cpp
@@ -360,22 +360,8 @@ namespace pksm
     {
         if (v == 1 || v == 2)
         {
-            if (shiny())
-            {
-                do
-                {
-                    PID(PKX::getRandomPID(species(), gender(), version(), nature(),
-                        alternativeForm(), v, PID(), generation()));
-                } while (!shiny());
-            }
-            else
-            {
-                do
-                {
-                    PID(PKX::getRandomPID(species(), gender(), version(), nature(),
-                        alternativeForm(), v, PID(), generation()));
-                } while (shiny());
-            }
+            PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(), v,
+                shiny(), TSV(), PID(), generation()));
             hiddenAbility(false);
         }
         else // Hidden ability
@@ -511,22 +497,8 @@ namespace pksm
     void PK5::gender(Gender g)
     {
         data[0x40] = (data[0x40] & ~0x06) | (u8(g) << 1);
-        if (shiny())
-        {
-            do
-            {
-                PID(PKX::getRandomPID(species(), g, version(), nature(), alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            } while (!shiny());
-        }
-        else
-        {
-            do
-            {
-                PID(PKX::getRandomPID(species(), g, version(), nature(), alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            } while (shiny());
-        }
+        PID(PKX::getRandomPID(species(), g, version(), nature(), alternativeForm(), abilityNumber(),
+            shiny(), TSV(), PID(), generation()));
     }
 
     u16 PK5::alternativeForm(void) const { return data[0x40] >> 3; }
@@ -674,22 +646,8 @@ namespace pksm
     bool PK5::shiny(void) const { return TSV() == PSV(); }
     void PK5::shiny(bool v)
     {
-        if (v)
-        {
-            while (!shiny())
-            {
-                PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            }
-        }
-        else
-        {
-            while (shiny())
-            {
-                PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            }
-        }
+        PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
+            abilityNumber(), v, TSV(), PID(), generation()));
     }
 
     u16 PK5::formSpecies(void) const

--- a/source/pkx/PK6.cpp
+++ b/source/pkx/PK6.cpp
@@ -640,22 +640,8 @@ namespace pksm
     bool PK6::shiny(void) const { return TSV() == PSV(); }
     void PK6::shiny(bool v)
     {
-        if (v)
-        {
-            while (!shiny())
-            {
-                PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            }
-        }
-        else
-        {
-            while (shiny())
-            {
-                PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            }
-        }
+        PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
+            abilityNumber(), v, TSV(), PID(), generation()));
     }
 
     u16 PK6::formSpecies(void) const

--- a/source/pkx/PK7.cpp
+++ b/source/pkx/PK7.cpp
@@ -600,22 +600,8 @@ namespace pksm
     bool PK7::shiny(void) const { return TSV() == PSV(); }
     void PK7::shiny(bool v)
     {
-        if (v)
-        {
-            while (!shiny())
-            {
-                PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            }
-        }
-        else
-        {
-            while (shiny())
-            {
-                PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            }
-        }
+        PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
+            abilityNumber(), v, TSV(), PID(), generation()));
     }
 
     u16 PK7::formSpecies(void) const

--- a/source/pkx/PK8.cpp
+++ b/source/pkx/PK8.cpp
@@ -797,22 +797,8 @@ namespace pksm
     bool PK8::shiny(void) const { return TSV() == PSV(); }
     void PK8::shiny(bool v)
     {
-        if (v)
-        {
-            while (!shiny())
-            {
-                PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            }
-        }
-        else
-        {
-            while (shiny())
-            {
-                PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
-                    abilityNumber(), PID(), generation()));
-            }
-        }
+        PID(PKX::getRandomPID(species(), gender(), version(), nature(), alternativeForm(),
+            abilityNumber(), v, TSV(), PID(), generation()));
     }
 
     u16 PK8::formSpecies(void) const

--- a/source/pkx/PKX.cpp
+++ b/source/pkx/PKX.cpp
@@ -307,7 +307,7 @@ namespace pksm
     }
 
     u32 PKX::getRandomPID(Species species, Gender gender, GameVersion originGame, Nature nature,
-        u8 form, u8 abilityNum, u32 oldPid, Generation gen)
+        u8 form, u8 abilityNum, bool shiny, u16 tsv, u32 oldPid, Generation gen)
     {
         if (originGame >= GameVersion::X) // Origin game over gen 5
         {
@@ -352,6 +352,7 @@ namespace pksm
         bool g3unown  = (originGame <= GameVersion::LG || gen == Generation::THREE) &&
                        species == Species::Unown;
         u32 abilityBits = oldPid & (abilityNum == 2 ? 0x00010001 : 0);
+        int psvShift    = gen >= Generation::SIX ? 4 : 3;
         while (true)
         {
             u32 possiblePID = pksm::randomNumber(0, 0xFFFFFFFF);
@@ -368,6 +369,12 @@ namespace pksm
                 }
             }
             else if (abilityBits != (possiblePID & 0x00010001))
+            {
+                continue;
+            }
+
+            u16 psv = (possiblePID >> 16 ^ (possiblePID & 0xFFFF)) >> psvShift;
+            if ((tsv == psv) != shiny)
             {
                 continue;
             }


### PR DESCRIPTION
It seems I(?) forgot to set the nature in the PK3<->PK4 transfer functions, so it was being reset to default.

Tested with [pkmn-chest.nds.zip](https://github.com/FlagBrew/PKSM-Core/files/9033731/pkmn-chest.nds.zip)

 