### PR TITLE
Allow mGBA save files with RTC

### DIFF
--- a/source/sav/Sav.cpp
+++ b/source/sav/Sav.cpp
@@ -72,6 +72,7 @@ namespace pksm
             case 0x80000:
                 return checkDSType(dt);
             case 0x20000:
+            case 0x20010:
                 return checkGBAType(dt);
             case 0x8000:
             case 0x10000:


### PR DESCRIPTION
See mgba-emu/mgba#240, since v0.10.0 mGBA adds a 16 byte RTC footer to the end of the save file. Since mGBA is on 3DS I think it's probably appropriate to allow these to be loaded in PKSM.